### PR TITLE
fix: set correct database encoding and permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ RUN zypper --non-interactive install postgresql14 postgresql14-libversion postgr
 RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 
 USER postgres
-RUN /usr/lib/postgresql14/bin/initdb -D /var/lib/pgsql/data
+RUN /usr/lib/postgresql14/bin/initdb --encoding=UTF8 -D /var/lib/pgsql/data
 ENV PGDATA=/var/lib/pgsql/data
 RUN pg_ctl --wait --mode immediate -D /var/lib/pgsql/data start -o "-F -c 'wal_level=minimal' -c 'max_wal_senders=0' -c 'max_replication_slots=0'" && \
-	psql -c "CREATE DATABASE repology" && \
+	psql -c "CREATE DATABASE repology encoding='UTF8'" && \
 	psql -c "CREATE USER repology WITH PASSWORD 'repology'" && \
 	psql --dbname repology -c "CREATE EXTENSION pg_trgm" && \
 	psql --dbname repology -c "CREATE EXTENSION libversion" && \
@@ -15,7 +15,7 @@ RUN pg_ctl --wait --mode immediate -D /var/lib/pgsql/data start -o "-F -c 'wal_l
 	curl --silent https://dumps.repology.org/repology-database-dump-latest.sql.zst | zstd -d | \
 	psql --dbname repology -v ON_ERROR_STOP=1 && \
         psql --dbname repology -c "GRANT CREATE ON SCHEMA public TO PUBLIC" && \
- 	psql -c "GRANT ALL ON DATABASE repology TO repology" && \
+ 	psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO repology" && \
 	pg_ctl --wait --mode immediate -D /var/lib/pgsql/data stop
 
 CMD postgres -c "listen_addresses=*" -D /var/lib/pgsql/data


### PR DESCRIPTION
This PR switches the default database encoding to UTF8 and corrects the permissions for the `repology` user.

The data from Repology contains UTF-8 which can't be decoded with SQL_ASCII which is the default. Using the webapp with this database container fails with a decoding message.