### PR TITLE
fix: do not cache the download of the Repology DB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,21 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 USER postgres
 RUN /usr/lib/postgresql14/bin/initdb --encoding=UTF8 -D /var/lib/pgsql/data
 ENV PGDATA=/var/lib/pgsql/data
+
+# do not use "RUN curl ..." as this would be executed once and the file would be cached
+ADD --chown=postgres:users https://dumps.repology.org/repology-database-dump-latest.sql.zst /tmp/
+
 RUN pg_ctl --wait --mode immediate -D /var/lib/pgsql/data start -o "-F -c 'wal_level=minimal' -c 'max_wal_senders=0' -c 'max_replication_slots=0'" && \
 	psql -c "CREATE DATABASE repology encoding='UTF8'" && \
 	psql -c "CREATE USER repology WITH PASSWORD 'repology'" && \
 	psql --dbname repology -c "CREATE EXTENSION pg_trgm" && \
 	psql --dbname repology -c "CREATE EXTENSION libversion" && \
 	echo "host    all             all             0.0.0.0/0            trust" >> /var/lib/pgsql/data/pg_hba.conf && \
-	curl --silent https://dumps.repology.org/repology-database-dump-latest.sql.zst | zstd -d | \
-	psql --dbname repology -v ON_ERROR_STOP=1 && \
+	zstd -d /tmp/repology-database-dump-latest.sql.zst | psql --dbname repology -v ON_ERROR_STOP=1 && \
         psql --dbname repology -c "GRANT CREATE ON SCHEMA public TO PUBLIC" && \
  	psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO repology" && \
-	pg_ctl --wait --mode immediate -D /var/lib/pgsql/data stop
+	pg_ctl --wait --mode immediate -D /var/lib/pgsql/data stop && \
+        rm /tmp/repology-database-dump-latest.sql.zst
 
 CMD postgres -c "listen_addresses=*" -D /var/lib/pgsql/data
 EXPOSE 5432

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ USER postgres
 RUN /usr/lib/postgresql14/bin/initdb --encoding=UTF8 -D /var/lib/pgsql/data
 ENV PGDATA=/var/lib/pgsql/data
 
-# do not use "RUN curl ..." as this would be executed once and the file would be cached
+# do not use "RUN curl ..." as this would be executed once and the layer would be cached
 ADD --chown=postgres:users https://dumps.repology.org/repology-database-dump-latest.sql.zst /tmp/
 
 RUN pg_ctl --wait --mode immediate -D /var/lib/pgsql/data start -o "-F -c 'wal_level=minimal' -c 'max_wal_senders=0' -c 'max_replication_slots=0'" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN /usr/lib/postgresql14/bin/initdb --encoding=UTF8 -D /var/lib/pgsql/data
 ENV PGDATA=/var/lib/pgsql/data
 
 # do not use "RUN curl ..." as this would be executed once and the layer would be cached
-ADD --chown=postgres:users https://dumps.repology.org/repology-database-dump-latest.sql.zst /tmp/
+ADD --chown=postgres:postgres https://dumps.repology.org/repology-database-dump-latest.sql.zst /tmp/
 
 RUN pg_ctl --wait --mode immediate -D /var/lib/pgsql/data start -o "-F -c 'wal_level=minimal' -c 'max_wal_senders=0' -c 'max_replication_slots=0'" && \
 	psql -c "CREATE DATABASE repology encoding='UTF8'" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pg_ctl --wait --mode immediate -D /var/lib/pgsql/data start -o "-F -c 'wal_l
 	psql --dbname repology -c "CREATE EXTENSION pg_trgm" && \
 	psql --dbname repology -c "CREATE EXTENSION libversion" && \
 	echo "host    all             all             0.0.0.0/0            trust" >> /var/lib/pgsql/data/pg_hba.conf && \
-	zstd -d /tmp/repology-database-dump-latest.sql.zst | psql --dbname repology -v ON_ERROR_STOP=1 && \
+	zstd -dc /tmp/repology-database-dump-latest.sql.zst | psql --dbname repology -v ON_ERROR_STOP=1 && \
         psql --dbname repology -c "GRANT CREATE ON SCHEMA public TO PUBLIC" && \
  	psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO repology" && \
 	pg_ctl --wait --mode immediate -D /var/lib/pgsql/data stop && \


### PR DESCRIPTION
The Repology database dump was downloaded with `RUN curl https://dumps....` which results in caching the layer as the `RUN` statement itself never changes. Thus the dump is never downloaded again as long as the `RUN` statement remains unchanged.

Using `ADD` avoids caching this layer and downloads it every time.