### PR TITLE
chore: dummy update to trigger a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ per https://github.com/repology/repology-webapp/issues/65.
 ## How to Use
 
 TODO
+
+
+<!-- dummy update to have a commit newer than 60 days. Otherwise the scheduled workflows are disabled. -->


### PR DESCRIPTION
... workflows are deactivated after 60 days of no activity by GitHub.