### PR TITLE
fix: change schema to `repology`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN pg_ctl --wait --mode immediate -D /var/lib/pgsql/data start -o "-F -c 'wal_l
 	psql --dbname repology -c "CREATE EXTENSION libversion" && \
 	echo "host    all             all             0.0.0.0/0            trust" >> /var/lib/pgsql/data/pg_hba.conf && \
 	zstd -dc /tmp/repology-database-dump-latest.sql.zst | psql --dbname repology -v ON_ERROR_STOP=1 && \
-        psql --dbname repology -c "GRANT CREATE ON SCHEMA public TO PUBLIC" && \
- 	psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO repology" && \
+        psql --dbname repology -c "GRANT CREATE, USAGE ON SCHEMA repology TO repology" && \
+ 	psql -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA repology TO repology" && \
 	pg_ctl --wait --mode immediate -D /var/lib/pgsql/data stop && \
         rm /tmp/repology-database-dump-latest.sql.zst
 


### PR DESCRIPTION
With the new Rust rebuild of the applications all tables were moved to the `repology` schema. So granting for `public` does not work here.