### PR TITLE
fix: do a clean shutdown and allow enough time to start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,11 @@ RUN pg_ctl --wait --mode immediate -D /var/lib/pgsql/data start -o "-F -c 'wal_l
 	zstd -dc /tmp/repology-database-dump-latest.sql.zst | psql --dbname repology -v ON_ERROR_STOP=1 && \
         psql --dbname repology -c "GRANT CREATE, USAGE ON SCHEMA repology TO repology" && \
  	psql --dbname repology -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA repology TO repology" && \
-	pg_ctl --wait --mode immediate -D /var/lib/pgsql/data stop && \
+	pg_ctl --wait --mode fast -D /var/lib/pgsql/data stop && \
         rm /tmp/repology-database-dump-latest.sql.zst
 
 CMD postgres -c "listen_addresses=*" -D /var/lib/pgsql/data
 EXPOSE 5432
-HEALTHCHECK --interval=10s --timeout=3s --start-period=30s --retries=3 CMD pg_isready
+
+# takes a long time to start: 4 CPUs, 8G RAM --> 370s
+HEALTHCHECK --interval=10s --timeout=3s --start-period=480s --retries=3 CMD pg_isready


### PR DESCRIPTION
- if immediate shutdown is done, a recovery is executed on next start-up which takes up to 120s
- start-up time on 4 CPUs, 8G RAM roughly 370s. We allow a small buffer to be safe.